### PR TITLE
Don't use proxy for wget in healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,4 @@ ENV YOUTUBE_DL=$YOUTUBE_DL
 ENV YDL_CONFIG_PATH='/app_config'
 CMD [ "python", "-u", "./youtube-dl-server.py" ]
 
-HEALTHCHECK CMD wget 127.0.0.1:8080/api/info --spider -q
+HEALTHCHECK CMD wget 127.0.0.1:8080/api/info --spider -q -Y off


### PR DESCRIPTION
My docker infra is disconnected from the internet and running behind a proxy server for its internet access. Setting the http_proxy env variable on your container works, but unfortunately the healthcheck is not using the no_proxy variable. This is possibly a Docker limitation, but since it's attempting to wget localhost, which should never go through a proxy, it's a simple workaround not to use proxy at all for the healthcheck command.
Here's a quick and simple PR to disable proxy for the healthcheck, it might help other people as well.