### PR TITLE
Update dependency yt-dlp to v2025.3.26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ aiofiles==24.1.0
 Jinja2==3.1.6
 PyYAML==6.0.2
 youtube-dl==2021.12.17
-yt-dlp[default]==2025.3.21
+yt-dlp[default]==2025.3.26
 python-multipart==0.0.20


### PR DESCRIPTION
All downloads failed with `nsig extraction failed: Some formats may be missing`, the `2025.03.26` fixed that : https://github.com/yt-dlp/yt-dlp/releases/tag/2025.03.26